### PR TITLE
Fix simplex points iteration

### DIFF
--- a/ternary/plotting.py
+++ b/ternary/plotting.py
@@ -149,7 +149,7 @@ def simplex_points(steps=100, boundary_points=True):
         start = 1
     for i in range(start, steps + (1 - start)):
         for j in range(start, steps + (1 - start) - i):
-            k = steps - j - k
+            k = steps - i - j
             yield (i, j, k)
 
 def triangle_coordinates(i, j, k=None):


### PR DESCRIPTION
There seemed to be a small typo in `plotting.py` after cleanup in [this commit](https://github.com/marcharper/python-ternary/commit/415bcadfd5ad8e34ae8b8009a8a4643e5092e722). It broke  heatmap example in `examples.py`.