### PR TITLE
Option to change colors of ticks, tick labels, and boundary.

### DIFF
--- a/examples/color_coded_heatmap.py
+++ b/examples/color_coded_heatmap.py
@@ -1,0 +1,42 @@
+import ternary
+import matplotlib.pyplot as plt
+
+# Function to visualize for heat map
+def f(x):
+    return 1.0 * x[0] / (1.0 * x[0] + 0.2 * x[1] + 0.05 * x[2])
+
+# dictionary of axes colors for bottom (b), left (l), right (r)
+axes_colors = {'b': 'g', 'l': 'r', 'r':'b'}
+
+scale = 10
+
+fig, ax = plt.subplots()
+ax.axis("off")
+figure, tax = ternary.figure(ax=ax, scale=scale)
+
+tax.heatmapf(f, boundary=False, 
+            style="hexagonal", cmap=plt.cm.get_cmap('Blues'),
+            cbarlabel='Component 0 uptake',
+            vmax=1.0, vmin=0.0)
+
+tax.boundary(linewidth=2.0, axes_colors=axes_colors)
+
+tax.left_axis_label("$x_1$", offset=0.16, color=axes_colors['l'])
+tax.right_axis_label("$x_0$", offset=0.16, color=axes_colors['r'])
+tax.bottom_axis_label("$x_2$", offset=-0.06, color=axes_colors['b'])
+
+tax.gridlines(multiple=1, linewidth=2,
+              horizontal_kwargs={'color':axes_colors['b']},
+              left_kwargs={'color':axes_colors['l']},
+              right_kwargs={'color':axes_colors['r']},
+              alpha=0.7)
+
+tax.ticks(axis='rlb', linewidth=1, locations=range(scale+1), clockwise=True,
+         axes_colors=axes_colors,
+         ticks=["%.1f" % (1.0 - 1.0 * i / scale) for i in range(scale+1)],
+         offset=0.03)
+tax.clear_matplotlib_ticks()
+
+tax._redraw_labels()
+plt.tight_layout()
+tax.show()

--- a/ternary/colormapping.py
+++ b/ternary/colormapping.py
@@ -68,17 +68,32 @@ def colormapper(value, lower=0, upper=1, cmap=None):
     hex_ = rgb2hex(rgba)
     return hex_
 
-def colorbar_hack(ax, vmin, vmax, cmap, scientific=False):
-    """Colorbar hack to insert colorbar on ternary plot. Called by heatmap, 
-    not intended for direct usage."""
+def colorbar_hack(ax, vmin, vmax, cmap, scientific=False, cbarlabel=None):
+    """
+    Colorbar hack to insert colorbar on ternary plot. 
+    
+    Called by heatmap, not intended for direct usage.
+    
+    Parameters
+    ----------
+    vmin: float
+        Minimum value to portray in colorbar
+    vmax: float
+        Maximum value to portray in colorbar
+    cmap: Matplotlib colormap
+        Matplotlib colormap to use
+
+    """
     # http://stackoverflow.com/questions/8342549/matplotlib-add-colorbar-to-a-sequence-of-line-plots
     norm = pyplot.Normalize(vmin=vmin, vmax=vmax)
     sm = pyplot.cm.ScalarMappable(cmap=cmap, norm=norm)
     # Fake up the array of the scalar mappable. Urgh...
     sm._A = []
-    cb = pyplot.colorbar(sm, ax=ax, format='%.4f')
-    cb.locator = matplotlib.ticker.LinearLocator(numticks=7)
+    cb = pyplot.colorbar(sm, ax=ax)
+    if cbarlabel is not None:
+        cb.set_label(cbarlabel)
     if scientific:
+        cb.locator = matplotlib.ticker.LinearLocator(numticks=7)
         cb.formatter = matplotlib.ticker.ScalarFormatter()
         cb.formatter.set_powerlimits((0, 0))
-    cb.update_ticks()
+        cb.update_ticks()

--- a/ternary/heatmapping.py
+++ b/ternary/heatmapping.py
@@ -221,9 +221,9 @@ def heatmap(data, scale, vmin=None, vmax=None, cmap=None, ax=None,
             data[k] = numpy.array(v)
     else:
         cmap = get_cmap(cmap)
-        if not vmin:
+        if vmin is None:
             vmin = min(data.values())
-        if not vmax:
+        if vmax is None:
             vmax = max(data.values())
     style = style.lower()[0]
     if style not in ["t", "h", 'd']:

--- a/ternary/heatmapping.py
+++ b/ternary/heatmapping.py
@@ -179,7 +179,7 @@ def polygon_generator(data, scale, style, permutation=None):
 
 def heatmap(data, scale, vmin=None, vmax=None, cmap=None, ax=None,
             scientific=False, style='triangular', colorbar=True,
-            permutation=None, colormap=True):
+            permutation=None, colormap=True, cbarlabel=None):
     """
     Plots heatmap of given color values.
 
@@ -245,14 +245,15 @@ def heatmap(data, scale, vmin=None, vmax=None, cmap=None, ax=None,
         ax.fill(xs, ys, facecolor=color, edgecolor=color)
 
     if colorbar and colormap:
-        colorbar_hack(ax, vmin, vmax, cmap, scientific=scientific)
+        colorbar_hack(ax, vmin, vmax, cmap, scientific=scientific,
+                      cbarlabel=cbarlabel)
     return ax
 
 ## User Convenience Functions ##
 
 def heatmapf(func, scale=10, boundary=True, cmap=None, ax=None,
              scientific=False, style='triangular', colorbar=True,
-             permutation=None, vmin=None, vmax=None):
+             permutation=None, vmin=None, vmax=None, cbarlabel=None):
     """
     Computes func on heatmap partition coordinates and plots heatmap. In other
     words, computes the function on lattice points of the simplex (normalized
@@ -295,7 +296,8 @@ def heatmapf(func, scale=10, boundary=True, cmap=None, ax=None,
     # Pass everything to the heatmapper
     ax = heatmap(data, scale, cmap=cmap, ax=ax, style=style,
                  scientific=scientific, colorbar=colorbar,
-                 permutation=permutation, vmin=vmin, vmax=vmax)
+                 permutation=permutation, vmin=vmin, vmax=vmax, 
+                 cbarlabel=cbarlabel)
     return ax
 
 def svg_polygon(coordinates, color):

--- a/ternary/lines.py
+++ b/ternary/lines.py
@@ -93,7 +93,7 @@ def right_parallel_line(ax, scale, i, **kwargs):
 
 ## Boundary, Gridlines ##
 
-def boundary(ax, scale, **kwargs):
+def boundary(ax, scale, axes_colors=None, **kwargs):
     """
     Plots the boundary of the simplex. Creates and returns matplotlib axis if
     none given.
@@ -106,11 +106,21 @@ def boundary(ax, scale, **kwargs):
         Simplex scale size.
     kwargs:
         Any kwargs to pass through to matplotlib.
+    axes_colors: dict
+        Option for coloring boundaries different colors.
+        e.g. {'l': 'g'} for coloring the left axis boundary green
     """
+    
+    # set default color as blue
+    if axes_colors is None:
+        axes_colors = dict()
+    for _axis in ['l', 'r', 'b']:
+        if _axis not in axes_colors.keys():
+            axes_colors[_axis] = 'b'
 
-    horizontal_line(ax, scale, 0, **kwargs)
-    left_parallel_line(ax, scale, 0, **kwargs)
-    right_parallel_line(ax, scale, 0, **kwargs)
+    horizontal_line(ax, scale, 0, color=axes_colors['b'], **kwargs)
+    left_parallel_line(ax, scale, 0, color=axes_colors['l'], **kwargs)
+    right_parallel_line(ax, scale, 0, color=axes_colors['r'], **kwargs)
     return ax
 
 def merge_dicts(base, updates):

--- a/ternary/lines.py
+++ b/ternary/lines.py
@@ -176,7 +176,7 @@ def gridlines(ax, scale, multiple=None, horizontal_kwargs=None, left_kwargs=None
     return ax
 
 def ticks(ax, scale, ticks=None, locations=None, multiple=1, axis='b',
-          offset=0.01, clockwise=False, **kwargs):
+          offset=0.01, clockwise=False, axes_colors=None, **kwargs):
     """
     Sets tick marks and labels.
 
@@ -200,6 +200,9 @@ def ticks(ax, scale, ticks=None, locations=None, multiple=1, axis='b',
         controls the length of the ticks
     clockwise: bool, False
         Draw ticks marks clockwise or counterclockwise
+    axes_colors: Dict, None
+        Option to color ticks differently for each axis, 'l', 'r', 'b'
+        e.g. {'l': 'g', 'r':'b', 'b': 'y'}
     kwargs:
         Any kwargs to pass through to matplotlib.
 
@@ -214,6 +217,13 @@ def ticks(ax, scale, ticks=None, locations=None, multiple=1, axis='b',
     if not ticks:
         locations = arange(0, scale + multiple, multiple)
         ticks = locations
+
+    # default color: blue
+    if axes_colors is None:
+        axes_colors = dict()
+    for _axis in valid_axis_chars:
+        if _axis not in axes_colors:
+            axes_colors[_axis] = 'b'
 
     offset *= scale
 
@@ -230,9 +240,10 @@ def ticks(ax, scale, ticks=None, locations=None, multiple=1, axis='b',
                 loc2 = (scale - i + offset, i, 0)
                 text_location = (scale - i + 2.6 * offset, i - 0.5 * offset, 0)
                 tick = ticks[-(index+1)]
-            line(ax, loc1, loc2, **kwargs)
+            line(ax, loc1, loc2, color=axes_colors['r'], **kwargs)
             x, y = project_point(text_location)
-            ax.text(x, y, str(tick), horizontalalignment="center",)
+            ax.text(x, y, str(tick), horizontalalignment="center", 
+                color=axes_colors['r'])
 
     if 'l' in axis:
         for index, i in enumerate(locations):
@@ -248,9 +259,10 @@ def ticks(ax, scale, ticks=None, locations=None, multiple=1, axis='b',
                 text_location = (-2 * offset, i + 1.5 * offset, 0)
 
                 tick = ticks[index]
-            line(ax, loc1, loc2, **kwargs)
+            line(ax, loc1, loc2, color=axes_colors['l'], **kwargs)
             x, y = project_point(text_location)
-            ax.text(x, y, str(tick), horizontalalignment="center",)
+            ax.text(x, y, str(tick), horizontalalignment="center",
+                color=axes_colors['l'])
 
     if 'b' in axis:
         for index, i in enumerate(locations):
@@ -265,7 +277,7 @@ def ticks(ax, scale, ticks=None, locations=None, multiple=1, axis='b',
                 loc2 = (i, -offset, 0)
                 text_location = (i + 0.5 * offset, - 3.5 * offset, 0)
                 tick = ticks[-(index+1)]
-            line(ax, loc1, loc2, **kwargs)
+            line(ax, loc1, loc2, color=axes_colors['b'], **kwargs)
             x, y = project_point(text_location)
-            ax.text(x, y, str(tick), horizontalalignment="center",)
-
+            ax.text(x, y, str(tick), horizontalalignment="center",
+                color=axes_colors['b'])

--- a/ternary/ternary_axes_subplot.py
+++ b/ternary/ternary_axes_subplot.py
@@ -316,7 +316,7 @@ class TernaryAxesSubplot(object):
 
     def heatmap(self, data, scale=None, cmap=None, scientific=False,
                 style='triangular', colorbar=True, colormap=True,
-                vmin=None, vmax=None):
+                vmin=None, vmax=None, cbarlabel=None):
         permutation = self._permutation
         if not scale:
             scale = self.get_scale()
@@ -326,11 +326,11 @@ class TernaryAxesSubplot(object):
         heatmapping.heatmap(data, scale, cmap=cmap, style=style, ax=ax,
                             scientific=scientific, colorbar=colorbar,
                             permutation=permutation, colormap=colormap,
-                            vmin=vmin, vmax=vmax)
+                            vmin=vmin, vmax=vmax, cbarlabel=cbarlabel)
 
     def heatmapf(self, func, scale=None, cmap=None, boundary=True,
                  style='triangular', colorbar=True, scientific=True,
-                 vmin=None, vmax=None):
+                 vmin=None, vmax=None, cbarlabel=None):
         if not scale:
             scale = self.get_scale()
         if style.lower()[0] == 'd':
@@ -340,4 +340,4 @@ class TernaryAxesSubplot(object):
         heatmapping.heatmapf(func, scale, cmap=cmap, style=style,
                              boundary=boundary, ax=ax, scientific=scientific,
                              colorbar=colorbar, permutation=permutation,
-                             vmin=vmin, vmax=vmax)
+                             vmin=vmin, vmax=vmax, cbarlabel=cbarlabel)

--- a/ternary/ternary_axes_subplot.py
+++ b/ternary/ternary_axes_subplot.py
@@ -194,13 +194,13 @@ class TernaryAxesSubplot(object):
 
     # Boundary and Gridlines
 
-    def boundary(self, scale=None, **kwargs):
+    def boundary(self, scale=None, axes_colors=None, **kwargs):
         # Sometimes you want to draw a bigger boundary
         if not scale:
             scale = self._boundary_scale # defaults to self._scale
         ax = self.get_axes()
         self.resize_drawing_canvas(scale)
-        lines.boundary(scale=scale, ax=ax, **kwargs)
+        lines.boundary(scale=scale, ax=ax, axes_colors=axes_colors, **kwargs)
 
     def gridlines(self, multiple=None, horizontal_kwargs=None, left_kwargs=None,
                   right_kwargs=None, **kwargs):

--- a/ternary/ternary_axes_subplot.py
+++ b/ternary/ternary_axes_subplot.py
@@ -256,12 +256,12 @@ class TernaryAxesSubplot(object):
         plotting.clear_matplotlib_ticks(ax=ax, axis=axis)
 
     def ticks(self, ticks=None, locations=None, multiple=1, axis='blr',
-              clockwise=False, **kwargs):
+              clockwise=False, axes_colors=None, **kwargs):
         ax = self.get_axes()
         scale = self.get_scale()
         lines.ticks(ax, scale, ticks=ticks, locations=locations,
                     multiple=multiple, clockwise=clockwise, axis=axis, 
-                    **kwargs)
+                    axes_colors=axes_colors, **kwargs)
 
     # Redrawing and resizing
 


### PR DESCRIPTION
![example](https://cloud.githubusercontent.com/assets/4196261/11044842/1c4e8672-86d9-11e5-8f64-7db7ec53e796.png)

Capability to make a plot like this.

I also changed the color bar hack because it was displaying 0.2 as 0.2 times 1e0, which is silly.

Consider setting as default:

    ax.axis("off")

Since the box in Matplotlib does not have much significance for these ternary plots.

My example to produce the above plot is in the `examples` folder. Perhaps others can place their examples as separate scripts here...