### PR TITLE
Added left,right,top_corner_label methods 

### DIFF
--- a/ternary/ternary_axes_subplot.py
+++ b/ternary/ternary_axes_subplot.py
@@ -137,6 +137,31 @@ class TernaryAxesSubplot(object):
             position = (-offset, 3./5, 2./5)
         self._labels["left"] = (label, position, rotation, kwargs)
 
+    def right_corner_label(self, label, position=None,  rotation=0, offset=0.08,
+                        **kwargs):
+        """
+        Sets the label on the right corner (complements left axis).
+
+        Parameters
+        ----------
+        ax: Matplotlib AxesSubplot, None
+            The subplot to draw on.
+        label: String
+            The axis label
+        position: 3-Tuple of floats, None
+            The position of the text label
+        rotation: float, 0
+            The angle of rotation of the label
+        offset: float,
+            Used to compute the distance of the label from the axis
+        kwargs:
+            Any kwargs to pass through to matplotlib.
+        """
+
+        if not position:
+            position = (1, offset, 0)
+        self._labels["left"] = (label, position, rotation, kwargs)
+
     def right_axis_label(self, label, position=None, rotation=-60, offset=0.08,
                          **kwargs):
         """
@@ -162,6 +187,31 @@ class TernaryAxesSubplot(object):
             position = (2./5 + offset, 3./5, 0)
         self._labels["right"] = (label, position, rotation, kwargs)
 
+    def left_corner_label(self, label, position=None, rotation=-0, offset=0.08,
+                         **kwargs):
+        """
+        Sets the label on the left corner (complements right axis.)
+
+        Parameters
+        ----------
+        ax: Matplotlib AxesSubplot, None
+            The subplot to draw on.
+        label: String
+            The axis label
+        position: 3-Tuple of floats, None
+            The position of the text label
+        rotation: float, 0
+            The angle of rotation of the label
+        offset: float,
+            Used to compute the distance of the label from the axis
+        kwargs:
+            Any kwargs to pass through to matplotlib.
+        """
+
+        if not position:
+            position = (-offset, offset, -offset/2)
+        self._labels["right"] = (label, position, rotation, kwargs)
+
     def bottom_axis_label(self, label, position=None, rotation=0, offset=0.02,
                           **kwargs):
         """
@@ -185,6 +235,31 @@ class TernaryAxesSubplot(object):
 
         if not position:
             position = (1./2, offset, 1./2)
+        self._labels["bottom"] = (label, position, rotation, kwargs)
+
+    def top_corner_label(self, label, position=None, rotation=0, offset=0.2,
+                          **kwargs):
+        """
+        Sets the label on the bottom axis.
+
+        Parameters
+        ----------
+        ax: Matplotlib AxesSubplot, None
+            The subplot to draw on.
+        label: String
+            The axis label
+        position: 3-Tuple of floats, None
+            The position of the text label
+        rotation: float, 0
+            The angle of rotation of the label
+        offset: float,
+            Used to compute the distance of the label from the axis
+        kwargs:
+            Any kwargs to pass through to matplotlib.
+        """
+
+        if not position:
+            position = (-offset/2,1+offset,0)
         self._labels["bottom"] = (label, position, rotation, kwargs)
 
     def annotate(self, text, position, **kwargs):


### PR DESCRIPTION
Added left,right,top_corner_label methods to allow labeling of ternary plot at each corner instead of along each axis.  Folks in geology tend to draw plots this way.  Future work might make the positioning of the labels within the canvas.
