### PR TITLE
Colorbar kwargs and vmin, vmax for scatter

### DIFF
--- a/examples/colorbar_kwargs.py
+++ b/examples/colorbar_kwargs.py
@@ -32,10 +32,9 @@ cb_kwargs = {"shrink" : 0.6,
              "pad" : 0.05,
              "aspect" : 30}
 
-tax.scatter(points,marker='s',c=c,edgecolor='k',s=40,linewidths=0.5,\
-                                    vmin=0,vmax=100,colorbar=True,\
-                                colormap='jet',cbarlabel='Farmers',\
-                                            cb_kwargs=cb_kwargs,zorder=3)
+tax.scatter(points,marker='s',c=c,edgecolor='k',s=40,linewidths=0.5,
+            vmin=0,vmax=100,colorbar=True,colormap='jet',cbarlabel='Farmers',
+            cb_kwargs=cb_kwargs,zorder=3)
 
 
 tax._redraw_labels()

--- a/examples/colorbar_kwargs.py
+++ b/examples/colorbar_kwargs.py
@@ -1,0 +1,91 @@
+import ternary
+
+## Boundary and Gridlines
+scale = 9
+figure, tax = ternary.figure(scale=scale)
+tax.ax.axis("off")
+figure.set_facecolor('w')
+
+# Draw Boundary and Gridlines
+tax.boundary(linewidth=1.0)
+tax.gridlines(color="black", multiple=1, linewidth=0.5,ls='-')
+
+# Set Axis labels and Title
+fontsize = 15
+#tax.set_title("Custom Ticklabels", fontsize=fontsize)
+tax.left_axis_label("Barleygrow", fontsize=fontsize, offset=0.12)
+tax.right_axis_label("Beans", fontsize=fontsize, offset=0.12)
+tax.bottom_axis_label("Oats", fontsize=fontsize, offset=0.025)
+
+# Set ticks
+tax.ticks(axis='blr', linewidth=1,multiple=1)
+
+
+
+# Scatter some points
+points = [(2,3,5),(3,6,1),(5,4,1),(3,4,3),(2,2,6)]
+c = [90,20,30,10,64]
+
+cb_kwargs = {"shrink" : 0.6,
+             "orientation" : "horizontal",
+             "fraction" : 0.1,
+             "pad" : 0.05,
+             "aspect" : 30}
+
+tax.scatter(points,marker='s',c=c,edgecolor='k',s=40,linewidths=0.5,\
+                                    vmin=0,vmax=100,colorbar=True,\
+                                colormap='jet',cbarlabel='Farmers',\
+                                            cb_kwargs=cb_kwargs,zorder=3)
+
+
+tax._redraw_labels()
+
+
+
+# Color coded heatmap example with colorbar kwargs
+# Slight modification so that we don't have to re-import pyplot
+# but make use of ternary.plt
+
+# Function to visualize for heat map
+def f(x):
+    return 1.0 * x[0] / (1.0 * x[0] + 0.2 * x[1] + 0.05 * x[2])
+
+# dictionary of axes colors for bottom (b), left (l), right (r)
+axes_colors = {'b': 'g', 'l': 'r', 'r':'b'}
+
+scale = 10
+
+figure, tax = ternary.figure(scale=scale)
+tax.ax.axis("off")
+cb_kwargs = {"shrink" : 0.6,
+             "pad" : 0.05,
+             "aspect" : 30,
+             "orientation" : "horizontal"}
+
+tax.heatmapf(f, boundary=False, 
+            style="hexagonal", cmap=ternary.plt.cm.get_cmap('Blues'),
+            cbarlabel='Component 0 uptake',
+            vmax=1.0, vmin=0.0, cb_kwargs=cb_kwargs)
+
+tax.boundary(linewidth=2.0, axes_colors=axes_colors)
+
+tax.left_axis_label("$x_1$", offset=0.16, color=axes_colors['l'])
+tax.right_axis_label("$x_0$", offset=0.16, color=axes_colors['r'])
+tax.bottom_axis_label("$x_2$", offset=-0.06, color=axes_colors['b'])
+
+tax.gridlines(multiple=1, linewidth=2,
+              horizontal_kwargs={'color':axes_colors['b']},
+              left_kwargs={'color':axes_colors['l']},
+              right_kwargs={'color':axes_colors['r']},
+              alpha=0.7)
+
+ticks = [round(i / float(scale), 1) for i in range(scale+1)]
+tax.ticks(ticks=ticks, axis='rlb', linewidth=1, clockwise=True,
+          axes_colors=axes_colors, offset=0.03)
+
+tax.clear_matplotlib_ticks()
+
+tax._redraw_labels()
+ternary.plt.tight_layout()
+
+ternary.plt.show()

--- a/ternary/colormapping.py
+++ b/ternary/colormapping.py
@@ -68,8 +68,8 @@ def colormapper(value, lower=0, upper=1, cmap=None):
     hex_ = rgb2hex(rgba)
     return hex_
 
-def colorbar_hack(ax, vmin, vmax, cmap, scientific=False, cbarlabel=None,\
-                                                                  **kwargs):
+def colorbar_hack(ax, vmin, vmax, cmap, scientific=False, cbarlabel=None,
+                  **kwargs):
     """
     Colorbar hack to insert colorbar on ternary plot. 
     

--- a/ternary/colormapping.py
+++ b/ternary/colormapping.py
@@ -68,7 +68,8 @@ def colormapper(value, lower=0, upper=1, cmap=None):
     hex_ = rgb2hex(rgba)
     return hex_
 
-def colorbar_hack(ax, vmin, vmax, cmap, scientific=False, cbarlabel=None):
+def colorbar_hack(ax, vmin, vmax, cmap, scientific=False, cbarlabel=None,\
+                                                                  **kwargs):
     """
     Colorbar hack to insert colorbar on ternary plot. 
     
@@ -89,7 +90,7 @@ def colorbar_hack(ax, vmin, vmax, cmap, scientific=False, cbarlabel=None):
     sm = pyplot.cm.ScalarMappable(cmap=cmap, norm=norm)
     # Fake up the array of the scalar mappable. Urgh...
     sm._A = []
-    cb = pyplot.colorbar(sm, ax=ax)
+    cb = pyplot.colorbar(sm, ax=ax, **kwargs)
     if cbarlabel is not None:
         cb.set_label(cbarlabel)
     if scientific:

--- a/ternary/heatmapping.py
+++ b/ternary/heatmapping.py
@@ -179,7 +179,7 @@ def polygon_generator(data, scale, style, permutation=None):
 
 def heatmap(data, scale, vmin=None, vmax=None, cmap=None, ax=None,
             scientific=False, style='triangular', colorbar=True,
-            permutation=None, colormap=True, cbarlabel=None):
+            permutation=None, colormap=True, cbarlabel=None, cb_kwargs=None):
     """
     Plots heatmap of given color values.
 
@@ -206,6 +206,8 @@ def heatmap(data, scale, vmin=None, vmax=None, cmap=None, ax=None,
         Show colorbar.
     permutation: string, None
         A permutation of the coordinates
+    cb_kwargs: dict
+        dict of kwargs to pass to colorbar
 
     Returns
     -------
@@ -245,7 +247,11 @@ def heatmap(data, scale, vmin=None, vmax=None, cmap=None, ax=None,
         ax.fill(xs, ys, facecolor=color, edgecolor=color)
 
     if colorbar and colormap:
-        colorbar_hack(ax, vmin, vmax, cmap, scientific=scientific,
+        if cb_kwargs != None:
+            colorbar_hack(ax, vmin, vmax, cmap, scientific=scientific,
+                      cbarlabel=cbarlabel, **cb_kwargs)
+        else:
+            colorbar_hack(ax, vmin, vmax, cmap, scientific=scientific,
                       cbarlabel=cbarlabel)
     return ax
 
@@ -253,7 +259,8 @@ def heatmap(data, scale, vmin=None, vmax=None, cmap=None, ax=None,
 
 def heatmapf(func, scale=10, boundary=True, cmap=None, ax=None,
              scientific=False, style='triangular', colorbar=True,
-             permutation=None, vmin=None, vmax=None, cbarlabel=None):
+             permutation=None, vmin=None, vmax=None, cbarlabel=None,
+             cb_kwargs=None):
     """
     Computes func on heatmap partition coordinates and plots heatmap. In other
     words, computes the function on lattice points of the simplex (normalized
@@ -283,6 +290,8 @@ def heatmapf(func, scale=10, boundary=True, cmap=None, ax=None,
         The minimum color value, used to normalize colors.
     vmax: float
         The maximum color value, used to normalize colors.
+    cb_kwargs: dict
+        dict of kwargs to pass to colorbar
 
     Returns
     -------
@@ -297,7 +306,7 @@ def heatmapf(func, scale=10, boundary=True, cmap=None, ax=None,
     ax = heatmap(data, scale, cmap=cmap, ax=ax, style=style,
                  scientific=scientific, colorbar=colorbar,
                  permutation=permutation, vmin=vmin, vmax=vmax, 
-                 cbarlabel=cbarlabel)
+                 cbarlabel=cbarlabel, cb_kwargs=cb_kwargs)
     return ax
 
 def svg_polygon(coordinates, color):

--- a/ternary/heatmapping.py
+++ b/ternary/heatmapping.py
@@ -249,10 +249,10 @@ def heatmap(data, scale, vmin=None, vmax=None, cmap=None, ax=None,
     if colorbar and colormap:
         if cb_kwargs != None:
             colorbar_hack(ax, vmin, vmax, cmap, scientific=scientific,
-                      cbarlabel=cbarlabel, **cb_kwargs)
+                          cbarlabel=cbarlabel, **cb_kwargs)
         else:
             colorbar_hack(ax, vmin, vmax, cmap, scientific=scientific,
-                      cbarlabel=cbarlabel)
+                          cbarlabel=cbarlabel)
     return ax
 
 ## User Convenience Functions ##

--- a/ternary/plotting.py
+++ b/ternary/plotting.py
@@ -113,8 +113,12 @@ def plot_colored_trajectory(points, cmap=None, ax=None, permutation=None,
 
     return ax
 
-def scatter(points, ax=None, permutation=None, colorbar=False, colormap=None, cbarlabel=None, vmin=0, vmax = 1, **kwargs):
-    """Plots trajectory points where each point satisfies x + y + z = scale. First argument is a list or numpy array of tuples of length 3.
+def scatter(points, ax=None, permutation=None, colorbar=False, colormap=None,\
+                                        vmin=0, vmax=1, scientific=False, \
+                                    cbarlabel=None, cb_kwargs=None, **kwargs):
+    """
+    Plots trajectory points where each point satisfies x + y + z = scale.
+    First argument is a list or numpy array of tuples of length 3.
 
     Parameters
     ----------
@@ -130,6 +134,8 @@ def scatter(points, ax=None, permutation=None, colorbar=False, colormap=None, cb
         Minimum value for colorbar.
     vmax: int, 1
         Maximum value for colorbar.
+    cb_kwargs: dict
+        Any additional kwargs to pass to colorbar
     kwargs:
         Any kwargs to pass through to matplotlib.
     """
@@ -139,6 +145,11 @@ def scatter(points, ax=None, permutation=None, colorbar=False, colormap=None, cb
     ax.scatter(xs, ys, vmin=vmin, vmax=vmax, **kwargs)
 
     if colorbar and (colormap != None):
-        colorbar_hack(ax, vmin, vmax, colormap, cbarlabel=cbarlabel)
+        if cb_kwargs != None:
+            colorbar_hack(ax, vmin, vmax, colormap, scientific=scientific,\
+                                              cbarlabel=cbarlabel, **cb_kwargs)
+        else:
+            colorbar_hack(ax, vmin, vmax, colormap, scientific=scientific,\
+                                                          cbarlabel=cbarlabel)
 
     return ax

--- a/ternary/plotting.py
+++ b/ternary/plotting.py
@@ -113,9 +113,9 @@ def plot_colored_trajectory(points, cmap=None, ax=None, permutation=None,
 
     return ax
 
-def scatter(points, ax=None, permutation=None, colorbar=False, colormap=None,\
-                                        vmin=0, vmax=1, scientific=False, \
-                                    cbarlabel=None, cb_kwargs=None, **kwargs):
+def scatter(points, ax=None, permutation=None, colorbar=False, colormap=None,
+            vmin=0, vmax=1, scientific=False, cbarlabel=None, cb_kwargs=None,
+            **kwargs):
     """
     Plots trajectory points where each point satisfies x + y + z = scale.
     First argument is a list or numpy array of tuples of length 3.
@@ -146,10 +146,10 @@ def scatter(points, ax=None, permutation=None, colorbar=False, colormap=None,\
 
     if colorbar and (colormap != None):
         if cb_kwargs != None:
-            colorbar_hack(ax, vmin, vmax, colormap, scientific=scientific,\
-                                              cbarlabel=cbarlabel, **cb_kwargs)
+            colorbar_hack(ax, vmin, vmax, colormap, scientific=scientific,
+                          cbarlabel=cbarlabel, **cb_kwargs)
         else:
-            colorbar_hack(ax, vmin, vmax, colormap, scientific=scientific,\
-                                                          cbarlabel=cbarlabel)
+            colorbar_hack(ax, vmin, vmax, colormap, scientific=scientific,
+                          cbarlabel=cbarlabel)
 
     return ax

--- a/ternary/plotting.py
+++ b/ternary/plotting.py
@@ -136,7 +136,7 @@ def scatter(points, ax=None, permutation=None, colorbar=False, colormap=None, cb
     if not ax:
         fig, ax = pyplot.subplots()
     xs, ys = project_sequence(points, permutation=permutation)
-    ax.scatter(xs, ys, **kwargs)
+    ax.scatter(xs, ys, vmin=vmin, vmax=vmax, **kwargs)
 
     if colorbar and (colormap != None):
         colorbar_hack(ax, vmin, vmax, colormap, cbarlabel=cbarlabel)

--- a/ternary/ternary_axes_subplot.py
+++ b/ternary/ternary_axes_subplot.py
@@ -316,7 +316,7 @@ class TernaryAxesSubplot(object):
 
     def heatmap(self, data, scale=None, cmap=None, scientific=False,
                 style='triangular', colorbar=True, colormap=True,
-                vmin=None, vmax=None, cbarlabel=None):
+                vmin=None, vmax=None, cbarlabel=None, cb_kwargs=None):
         permutation = self._permutation
         if not scale:
             scale = self.get_scale()
@@ -326,11 +326,12 @@ class TernaryAxesSubplot(object):
         heatmapping.heatmap(data, scale, cmap=cmap, style=style, ax=ax,
                             scientific=scientific, colorbar=colorbar,
                             permutation=permutation, colormap=colormap,
-                            vmin=vmin, vmax=vmax, cbarlabel=cbarlabel)
+                            vmin=vmin, vmax=vmax, cbarlabel=cbarlabel,
+                            cb_kwargs=cb_kwargs)
 
     def heatmapf(self, func, scale=None, cmap=None, boundary=True,
                  style='triangular', colorbar=True, scientific=True,
-                 vmin=None, vmax=None, cbarlabel=None):
+                 vmin=None, vmax=None, cbarlabel=None, cb_kwargs=None):
         if not scale:
             scale = self.get_scale()
         if style.lower()[0] == 'd':
@@ -340,4 +341,5 @@ class TernaryAxesSubplot(object):
         heatmapping.heatmapf(func, scale, cmap=cmap, style=style,
                              boundary=boundary, ax=ax, scientific=scientific,
                              colorbar=colorbar, permutation=permutation,
-                             vmin=vmin, vmax=vmax, cbarlabel=cbarlabel)
+                             vmin=vmin, vmax=vmax, cbarlabel=cbarlabel,
+                             cb_kwargs=cb_kwargs)


### PR DESCRIPTION
It seems that the vmin and vmax kwargs need to be passed explicitly into the call to ax.scatter inside scatter in order to get the normalisation to work properly for scatter plots.

Also added the capability to pass kwargs to the colorbar for advanced plotting. I included some code to show the use of colorbar kwargs with both scatter plots and heatmaps.

P.S. Thanks a lot for python-ternary, I've enjoyed using it to plot some data for a paper I'm writing.