### PR TITLE
Added custom axis scaling and tick label formatting

### DIFF
--- a/examples/custom_axis_scaling.py
+++ b/examples/custom_axis_scaling.py
@@ -1,0 +1,147 @@
+import ternary
+
+## Simple example:
+## Boundary and Gridlines
+scale = 9
+figure, tax = ternary.figure(scale=scale)
+
+tax.ax.axis("off")
+figure.set_facecolor('w')
+
+# Draw Boundary and Gridlines
+tax.boundary(linewidth=1.0)
+tax.gridlines(color="black", multiple=1, linewidth=0.5,ls='-')
+
+# Set Axis labels and Title
+fontsize = 16
+tax.left_axis_label("Logs", fontsize=fontsize, offset=0.13)
+tax.right_axis_label("Dogs", fontsize=fontsize, offset=0.12)
+tax.bottom_axis_label("Hogs", fontsize=fontsize, offset=0.06)
+
+
+# Set custom axis limits by passing a dict into set_limits.
+# The keys are b, l and r for the three axes and the vals are a list
+# of the min and max in data coords for that axis. max-min for each
+# axis must be the same as the scale i.e. 9 in this case.
+tax.set_axis_limits({'b':[67,76],'l':[24,33],'r':[0,9]})
+# get and set the custom ticks:
+tax.get_ticks_from_axis_limits()
+tax.set_custom_ticks(fsize=10,offset=0.02)
+
+# data can be plotted by entering data coords (rather than simplex coords):
+points = [(70,3,27),(73,2,25),(68,6,26)]
+points_c = tax.convert_coordinates(points,axisorder='brl')
+tax.scatter(points_c,marker='o',s=25,c='r')
+
+tax.ax.set_aspect('equal', adjustable='box')
+tax._redraw_labels()
+
+
+## Simple example with axis tick formatting:
+## Boundary and Gridlines
+scale = 9
+figure, tax = ternary.figure(scale=scale)
+
+tax.ax.axis("off")
+figure.set_facecolor('w')
+
+# Draw Boundary and Gridlines
+tax.boundary(linewidth=1.0)
+tax.gridlines(color="black", multiple=1, linewidth=0.5,ls='-')
+
+# Set Axis labels and Title
+fontsize = 16
+tax.left_axis_label("Logs", fontsize=fontsize, offset=0.13)
+tax.right_axis_label("Dogs", fontsize=fontsize, offset=0.12)
+tax.bottom_axis_label("Hogs", fontsize=fontsize, offset=0.06)
+
+
+# Set custom axis limits by passing a dict into set_limits.
+# The keys are b, l and r for the three axes and the vals are a list
+# of the min and max in data coords for that axis. max-min for each
+# axis must be the same as the scale i.e. 9 in this case.
+tax.set_axis_limits({'b':[67,76],'l':[24,33],'r':[0,9]})
+# get and set the custom ticks:
+# custom tick formats:
+# tick_formats can either be a dict, like below or a single format string
+# e.g. "%.3e" (valid for all 3 axes) or None, in which case, ints are
+# plotted for all 3 axes.
+tick_formats = {'b' : "%.2f",'r' : "%d",'l' : "%.1f"}
+
+tax.get_ticks_from_axis_limits()
+tax.set_custom_ticks(fsize=10,offset=0.02,tick_formats=tick_formats)
+
+# data can be plotted by entering data coords (rather than simplex coords):
+points = [(70,3,27),(73,2,25),(68,6,26)]
+points_c = tax.convert_coordinates(points,axisorder='brl')
+tax.scatter(points_c,marker='o',s=25,c='r')
+
+tax.ax.set_aspect('equal', adjustable='box')
+tax._redraw_labels()
+
+
+
+## Zoom example:
+## Draw a plot with the full range on the left and a second plot which
+## shows a zoomed region of the left plot.
+fig = ternary.plt.figure(figsize=(11,6))
+ax1 = fig.add_subplot(2,1,1)
+ax2 = fig.add_subplot(2,1,2)
+
+tax1 = ternary.TernaryAxesSubplot(ax=ax1,scale=100)
+tax1.boundary(linewidth=1.0)
+tax1.gridlines(color="black", multiple=10, linewidth=0.5,ls='-')
+tax1.ax.axis("equal")
+tax1.ax.axis("off")
+
+tax2 = ternary.TernaryAxesSubplot(ax=ax2,scale=30)
+axes_colors = {'b' : 'r',
+               'r' : 'r',
+               'l' : 'r'
+               }
+tax2.boundary(linewidth=1.0,axes_colors=axes_colors)
+tax2.gridlines(color="r", multiple=5, linewidth=0.5,ls='-')
+tax2.ax.axis("equal")
+tax2.ax.axis("off")
+
+fontsize = 16
+tax1.set_title("Entire range")
+tax1.left_axis_label("Logs", fontsize=fontsize, offset=0.12)
+tax1.right_axis_label("Dogs", fontsize=fontsize, offset=0.12)
+tax1.bottom_axis_label("Hogs", fontsize=fontsize, offset=0.)
+tax2.set_title("Zoomed region",color='r')
+tax2.left_axis_label("Logs", fontsize=fontsize, offset=0.17,color='r')
+tax2.right_axis_label("Dogs", fontsize=fontsize, offset=0.17,color='r')
+tax2.bottom_axis_label("Hogs", fontsize=fontsize, offset=0.03,color='r')
+
+tax1.ticks(multiple=10,offset=0.02)
+
+tax2.set_axis_limits({'b':[60,75],'l':[15,30],'r':[10,25]})
+tax2.get_ticks_from_axis_limits(multiple=5)
+tick_formats = "%.1f"
+tax2.set_custom_ticks(fsize=10,offset=0.025,multiple=5,axes_colors=axes_colors,
+                      tick_formats=tick_formats)
+
+# plot some data
+points = [(62,12,26),(63.5,13.5,23),(65,14,21),(61,15,24),(62,16,22),
+          (67.5,14.5,18),(68.2,16.5,15.3),(62,22.5,15.5)]
+
+# data coords == simplex coords:
+tax1.scatter(points,marker='^',s=25,c='b')
+# data coords != simplex coords:
+points_c = tax2.convert_coordinates(points,axisorder='brl')
+tax2.scatter(points_c,marker='^',s=25,c='b')
+
+# draw the zoom region on the first plot
+tax1.line((60,10,30),(75,10,15),color='r',lw=2.0)
+tax1.line((60,10,30),(60,25,15),color='r',lw=2.0)
+tax1.line((75,10,15),(60,25,15),color='r',lw=2.0)
+
+fig.set_facecolor("w")
+
+tax1.ax.set_position([0.01,0.05,0.46,0.8])
+tax2.ax.set_position([0.50,0.05,0.46,0.8])
+
+tax1.resize_drawing_canvas()
+tax2.resize_drawing_canvas()
+ternary.plt.show()

--- a/ternary/helpers.py
+++ b/ternary/helpers.py
@@ -114,3 +114,86 @@ def project_sequence(s, permutation=None):
 
     xs, ys = unzip([project_point(p, permutation=permutation) for p in s])
     return xs, ys
+
+
+## Convert coordinates for custom plots with limits ##
+
+def convert_coordinates(q,conversion,axisorder):
+    """
+    Convert a 3-tuple in data coordinates into to simplex data
+    coordinates for plotting.
+
+    Parameters
+    ----------
+    q, 3-tuple
+       the point to be plotted in data coordinates
+
+    conversion, dict
+                keys = ['b','l','r']
+                vals = lambda function giving the conversion
+
+    axisorder, str giving the order of the axes for
+               the coordinate tuple e.g. 'blr' for bottom, left,
+               right coordinates.
+
+    Returns
+    -------
+    p, 3-tuple
+       the point converted to simplex coordinates
+    """
+    p = []
+    for k in range(3):
+        p.append(conversion[axisorder[k]](q[k]))
+
+    return tuple(p)
+
+
+def get_conversion(scale,limits):
+    """
+    Get the converion equations for each axis.
+
+    limits: dict  of min and max values for the axes in the order blr.
+    """
+    fb = float(scale)/float(limits['b'][1]-limits['b'][0])
+    fl = float(scale)/float(limits['l'][1]-limits['l'][0])
+    fr = float(scale)/float(limits['r'][1]-limits['r'][0])
+
+    conversion = {"b" : lambda x: (x-limits['b'][0])*fb,
+                  "l" : lambda x: (x-limits['l'][0])*fl,
+                  "r" : lambda x: (x-limits['r'][0])*fr
+                  }
+
+    return conversion
+    
+
+def convert_coordinates_sequence(qs,scale,limits,axisorder):
+    """
+    Take a sequence of 3-tuples in data coordinates and convert them
+    to simplex coordinates for plotting. This is needed for custom
+    plots where the scale of the simplex axes is set within limits rather
+    than being defined by the scale parameter.
+
+    Parameters
+    ----------
+    qs, sequence of 3-tuples
+       the points to be plotted in data coordinates
+
+    scale, int
+                the scale parameter for the plot
+    
+    limits, dict
+                keys = ['b','l','r']
+                vals = min,max data values for this axis
+
+    axisorder, str giving the order of the axes for
+               the coordinate tuple e.g. 'blr' for bottom, left,
+               right coordinates.
+
+    Returns
+    -------
+    s, list of 3-tuples
+       the points converted to simplex coordinates
+    """
+    conversion = get_conversion(scale,limits)
+    
+    return [convert_coordinates(q,conversion,axisorder) for q in qs]

--- a/ternary/lines.py
+++ b/ternary/lines.py
@@ -186,7 +186,8 @@ def gridlines(ax, scale, multiple=None, horizontal_kwargs=None, left_kwargs=None
     return ax
 
 def ticks(ax, scale, ticks=None, locations=None, multiple=1, axis='b',
-          offset=0.01, clockwise=False, axes_colors=None, fsize = 10, **kwargs):
+          offset=0.01, clockwise=False, axes_colors=None, fsize = 10,
+          tick_formats=None, **kwargs):
     """
     Sets tick marks and labels.
 
@@ -213,6 +214,12 @@ def ticks(ax, scale, ticks=None, locations=None, multiple=1, axis='b',
     axes_colors: Dict, None
         Option to color ticks differently for each axis, 'l', 'r', 'b'
         e.g. {'l': 'g', 'r':'b', 'b': 'y'}
+    tick_formats: None, Dict, Str
+        If None, all axes will be labelled with ints. If Dict, the keys are
+        'b', 'l' and 'r' and the values are format strings e.g. "%.3f" for
+        a float with 3 decimal places or "%.3e" for scientific format with
+        3 decimal places or "%d" for ints. If tick_formats is a string, it
+        is assumed that this is a format string to be applied to all axes.
     kwargs:
         Any kwargs to pass through to matplotlib.
 
@@ -258,7 +265,16 @@ def ticks(ax, scale, ticks=None, locations=None, multiple=1, axis='b',
                 tick = ticks[index]
             line(ax, loc1, loc2, color=axes_colors['r'], **kwargs)
             x, y = project_point(text_location)
-            ax.text(x, y, str(tick), horizontalalignment="center", 
+            if tick_formats == None:
+                if type(tick) == int:
+                    s = str(tick)
+                else:
+                    s = str(int(tick))
+            elif type(tick_formats) == str:
+                s = tick_formats %(tick)
+            elif type(tick_formats == dict):
+                s = tick_formats['r'] %(tick)
+            ax.text(x, y, s, horizontalalignment="center", 
                 color=axes_colors['r'], fontsize=fsize)
 
     if 'l' in axis:
@@ -276,7 +292,16 @@ def ticks(ax, scale, ticks=None, locations=None, multiple=1, axis='b',
                 tick = ticks[-(index+1)]
             line(ax, loc1, loc2, color=axes_colors['l'], **kwargs)
             x, y = project_point(text_location)
-            ax.text(x, y, str(tick), horizontalalignment="center",
+            if tick_formats == None:
+                if type(tick) == int:
+                    s = str(tick)
+                else:
+                    s = str(int(tick))
+            elif type(tick_formats) == str:
+                s = tick_formats %(tick)
+            elif type(tick_formats == dict):
+                s = tick_formats['l'] %(tick)
+            ax.text(x, y, s, horizontalalignment="center",
                 color=axes_colors['l'], fontsize=fsize)
 
     if 'b' in axis:
@@ -294,5 +319,14 @@ def ticks(ax, scale, ticks=None, locations=None, multiple=1, axis='b',
                 tick = ticks[index]
             line(ax, loc1, loc2, color=axes_colors['b'], **kwargs)
             x, y = project_point(text_location)
-            ax.text(x, y, str(tick), horizontalalignment="center",
+            if tick_formats == None:
+                if type(tick) == int:
+                    s = str(tick)
+                else:
+                    s = str(int(tick))
+            elif type(tick_formats) == str:
+                s = tick_formats %(tick)
+            elif type(tick_formats == dict):
+                s = tick_formats['b'] %(tick)
+            ax.text(x, y, s, horizontalalignment="center",
                 color=axes_colors['b'], fontsize=fsize)

--- a/ternary/ternary_axes_subplot.py
+++ b/ternary/ternary_axes_subplot.py
@@ -184,7 +184,7 @@ class TernaryAxesSubplot(object):
         """
 
         if not position:
-            position = (1./2, offset, 1./2)
+            position = (1./2, -offset, 1./2)
         self._labels["bottom"] = (label, position, rotation, kwargs)
 
     def annotate(self, text, position, **kwargs):


### PR DESCRIPTION
Some more suggestions here which I found useful for my plots and which may help to address issues #47 and #24. Three commits (in chronological order).

1. Small change in the behaviour of the bottom_axis_label. Added a minus sign to the definition of position so that increasing the value of offset moves the label down, further below the axis. Seems more intuitive as the other two labels also move further away from the simplex when you increase offset.

2. Added ability to have custom scaling of the simplex e.g. the overall scale could be e.g. 10 but the individual axes can have different data scales e.g. 10 to 20, 34 to 44 and 56 to 66. Also included here is the ability to pass format strings into lines.ticks() so that any or all axes can have int, str or scientific notation.

3. Added a python file with examples of the above.