### PR TITLE
Update lines.py to allow for string tick labels

### DIFF
--- a/ternary/lines.py
+++ b/ternary/lines.py
@@ -287,7 +287,10 @@ def ticks(ax, scale, ticks=None, locations=None, multiple=1, axis='b',
                 tick = ticks[index]
             line(ax, loc1, loc2, color=axes_colors['r'], **kwargs)
             x, y = project_point(text_location)
-            s = tick_formats['r'] % tick
+            if isinstance(tick, str):
+                s = tick
+            else:
+                s = tick_formats['r'] % tick
             ax.text(x, y, s, horizontalalignment="center",
                     color=axes_colors['r'], fontsize=fontsize)
 
@@ -306,6 +309,10 @@ def ticks(ax, scale, ticks=None, locations=None, multiple=1, axis='b',
                 tick = ticks[-(index+1)]
             line(ax, loc1, loc2, color=axes_colors['l'], **kwargs)
             x, y = project_point(text_location)
+            if isinstance(tick, str):
+                s = tick
+            else:
+                s = tick_formats['r'] % tick
             s = tick_formats['l'] % tick
             ax.text(x, y, s, horizontalalignment="center",
                     color=axes_colors['l'], fontsize=fontsize)
@@ -325,6 +332,9 @@ def ticks(ax, scale, ticks=None, locations=None, multiple=1, axis='b',
                 tick = ticks[index]
             line(ax, loc1, loc2, color=axes_colors['b'], **kwargs)
             x, y = project_point(text_location)
-            s = tick_formats['b'] % tick
+            if isinstance(tick, str):
+                s = tick
+            else:
+                s = tick_formats['r'] % tick
             ax.text(x, y, s, horizontalalignment="center",
                     color=axes_colors['b'], fontsize=fontsize)

--- a/ternary/lines.py
+++ b/ternary/lines.py
@@ -312,7 +312,7 @@ def ticks(ax, scale, ticks=None, locations=None, multiple=1, axis='b',
             if isinstance(tick, str):
                 s = tick
             else:
-                s = tick_formats['r'] % tick
+                s = tick_formats['l'] % tick
             s = tick_formats['l'] % tick
             ax.text(x, y, s, horizontalalignment="center",
                     color=axes_colors['l'], fontsize=fontsize)
@@ -335,6 +335,6 @@ def ticks(ax, scale, ticks=None, locations=None, multiple=1, axis='b',
             if isinstance(tick, str):
                 s = tick
             else:
-                s = tick_formats['r'] % tick
+                s = tick_formats['b'] % tick
             ax.text(x, y, s, horizontalalignment="center",
                     color=axes_colors['b'], fontsize=fontsize)


### PR DESCRIPTION
Currently if you set your own tick labels which are strings rather than numbers you get an error. This change means that you can set tick labels as strings.