### PR TITLE
Pass **kwargs through axis savefig method

### DIFF
--- a/ternary/ternary_axes_subplot.py
+++ b/ternary/ternary_axes_subplot.py
@@ -313,10 +313,10 @@ class TernaryAxesSubplot(object):
         ax = self.get_axes()
         ax.legend(*args, **kwargs)
 
-    def savefig(self, filename, dpi=200, format=None):
+    def savefig(self, filename, dpi=200, format=None, **kwargs):
         self._redraw_labels()
         fig = self.get_figure()
-        fig.savefig(filename, format=format, dpi=dpi)
+        fig.savefig(filename, format=format, dpi=dpi, **kwargs)
 
     def show(self):
         self._redraw_labels()

--- a/ternary/ternary_axes_subplot.py
+++ b/ternary/ternary_axes_subplot.py
@@ -313,10 +313,12 @@ class TernaryAxesSubplot(object):
         ax = self.get_axes()
         ax.legend(*args, **kwargs)
 
-    def savefig(self, filename, dpi=200, format=None, **kwargs):
+    def savefig(self, filename, **kwargs):
         self._redraw_labels()
         fig = self.get_figure()
-        fig.savefig(filename, format=format, dpi=dpi, **kwargs)
+        if 'dpi' not in kwargs:
+            kwargs['dpi'] = 200
+        fig.savefig(filename, **kwargs)
 
     def show(self):
         self._redraw_labels()


### PR DESCRIPTION
Allows you to pass key words through to `figure.savefig` from the axis object, so that you can use useful arguments like `bbox_inches` directly.

Closes #114. 

