### PR TITLE
Include additional files in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,7 @@
+include *.md
 include *.txt
-include README.md
+include LICENSE
+
+graft examples
+graft readme_images
+graft tests


### PR DESCRIPTION
In particular include the license file, which the license text requires.  Also include tests, examples, and additional documentation.