### PR TITLE
Update call to set_x/yticks to avoid deprecation

### DIFF
--- a/ternary/plotting.py
+++ b/ternary/plotting.py
@@ -43,9 +43,9 @@ def clear_matplotlib_ticks(ax=None, axis="both"):
     if not ax:
         return
     if axis.lower() in ["both", "x", "horizontal"]:
-        ax.set_xticks([], [])
+        ax.set_xticks([], minor=False)
     if axis.lower() in ["both", "y", "vertical"]:
-        ax.set_yticks([], [])
+        ax.set_yticks([], minor=False)
 
 
 ## Curve Plotting ##


### PR DESCRIPTION
Matplotlib 3.2 updates `Axes.set_xticks()` and `Axes.set_yticks()` to expect `minor` only as a keyword argument, and gives a deprecation warning for callers using `minor` as a positional argument. This updates the call in `clear_matplotlib_ticks()` to use the newly recommended syntax (and hence avoid the deprecation warning).

See: https://matplotlib.org/3.2.0/api/_as_gen/matplotlib.axes.Axes.set_xticks.html