### PR TITLE
Remove stray line in tick format handling

### DIFF
--- a/ternary/lines.py
+++ b/ternary/lines.py
@@ -313,7 +313,6 @@ def ticks(ax, scale, ticks=None, locations=None, multiple=1, axis='b',
                 s = tick
             else:
                 s = tick_formats['l'] % tick
-            s = tick_formats['l'] % tick
             ax.text(x, y, s, horizontalalignment="center",
                     color=axes_colors['l'], fontsize=fontsize)
 


### PR DESCRIPTION
There's no analogous line in the right or bottom axes handling, so I assume this is a typo 🙂

(The effect of it is that, if the `ticks` argument is specified as a list of strings, `tick_formats` has to be `"%s"` for this line not to trigger a `TypeError`.)