### PR TITLE
Reposition tick labels

### DIFF
--- a/ternary/lines.py
+++ b/ternary/lines.py
@@ -278,20 +278,23 @@ def ticks(ax, scale, ticks=None, locations=None, multiple=1, axis='b',
             if clockwise:
                 # Right parallel
                 loc2 = (scale - i, i + offset, 0)
-                text_location = (scale - i, i + 2 * offset, 0)
+                text_location = (scale - i, i + 1.5 * offset, 0)
                 tick = ticks[-(index+1)]
+                valign = "baseline"
             else:
                 # Horizontal
                 loc2 = (scale - i + offset, i, 0)
-                text_location = (scale - i + 2.6 * offset, i - 0.5 * offset, 0)
+                text_location = (scale - i + 1.5 * offset, i, 0)
                 tick = ticks[index]
+                valign = "center"
             line(ax, loc1, loc2, color=axes_colors['r'], **kwargs)
             x, y = project_point(text_location)
             if isinstance(tick, str):
                 s = tick
             else:
                 s = tick_formats['r'] % tick
-            ax.text(x, y, s, horizontalalignment="center",
+            ax.text(x, y, s,
+                    horizontalalignment="left", verticalalignment=valign,
                     color=axes_colors['r'], fontsize=fontsize)
 
     if 'l' in axis:
@@ -300,20 +303,23 @@ def ticks(ax, scale, ticks=None, locations=None, multiple=1, axis='b',
             if clockwise:
                 # Horizontal
                 loc2 = (-offset, i, 0)
-                text_location = (-2 * offset, i - 0.5 * offset, 0)
+                text_location = (- 1.5 * offset, i, 0)
                 tick = ticks[index]
+                valign = "center"
             else:
                 # Right parallel
                 loc2 = (-offset, i + offset, 0)
-                text_location = (-2 * offset, i + 1.5 * offset, 0)
+                text_location = (-1.5 * offset, i + 1.5 * offset, 0)
                 tick = ticks[-(index+1)]
+                valign = "baseline"
             line(ax, loc1, loc2, color=axes_colors['l'], **kwargs)
             x, y = project_point(text_location)
             if isinstance(tick, str):
                 s = tick
             else:
                 s = tick_formats['l'] % tick
-            ax.text(x, y, s, horizontalalignment="center",
+            ax.text(x, y, s,
+                    horizontalalignment="right", verticalalignment=valign,
                     color=axes_colors['l'], fontsize=fontsize)
 
     if 'b' in axis:
@@ -322,12 +328,12 @@ def ticks(ax, scale, ticks=None, locations=None, multiple=1, axis='b',
             if clockwise:
                 # Right parallel
                 loc2 = (i + offset, -offset, 0)
-                text_location = (i + 3 * offset, -3.5 * offset, 0)
+                text_location = (i + 1.5 * offset, -1.5 * offset, 0)
                 tick = ticks[-(index+1)]
             else:
                 # Left parallel
                 loc2 = (i, -offset, 0)
-                text_location = (i + 0.5 * offset, -3.5 * offset, 0)
+                text_location = (i, -1.5 * offset, 0)
                 tick = ticks[index]
             line(ax, loc1, loc2, color=axes_colors['b'], **kwargs)
             x, y = project_point(text_location)
@@ -335,5 +341,6 @@ def ticks(ax, scale, ticks=None, locations=None, multiple=1, axis='b',
                 s = tick
             else:
                 s = tick_formats['b'] % tick
-            ax.text(x, y, s, horizontalalignment="center",
+            ax.text(x, y, s,
+                    horizontalalignment="center", verticalalignment="top",
                     color=axes_colors['b'], fontsize=fontsize)


### PR DESCRIPTION
This one's a little more involved and changes functionality a little, in a way that I should point out is arguably not backwards-compatible, if other users have been picky about their tick label positioning.

My idea here is to anchor (or align) the tick labels by the point that's "closest" to where the tick is, rather than the horizontal center and vertical baseline. This way, particularly with the parallel axis labels, if lengths of labels of different ticks are different (e.g. "0", "0.25", "0.5"), the length doesn't affect how far the label appears from the tick, and (sometimes) whether it "spills" onto the plot.

For example, on the left axis, when the ticks run horizontally, this PR makes them anchored right-middle, and when they run right-parallel, it makes them anchored right-bottom.

Because the anchors have moved to the nearest point, their offsets could be reduced a little.

There might be other considerations this risks breaking that I don't know about, so happy to discuss. I've just picked up on this package and am using it to plot probability simplex heatmaps, so thanks so much for making your project available!

To illustrate the effect:

**Before**
![image](https://user-images.githubusercontent.com/1725499/77274646-a1cfa400-6c73-11ea-97ad-d89e1945a923.png)

**After**
![image](https://user-images.githubusercontent.com/1725499/77274547-66cd7080-6c73-11ea-9092-d7cbc82409c3.png)

**Before, clockwise**
![image](https://user-images.githubusercontent.com/1725499/77274658-aac07580-6c73-11ea-8197-fd6f1444f50d.png)

**After, clockwise**
![image](https://user-images.githubusercontent.com/1725499/77274597-8369a880-6c73-11ea-9dd6-ab22e2d9a86c.png)