### PR TITLE
add norm to function args

### DIFF
--- a/ternary/colormapping.py
+++ b/ternary/colormapping.py
@@ -70,13 +70,13 @@ def colormapper(value, lower=0, upper=1, cmap=None):
     return hex_
 
 
-def colorbar_hack(ax, vmin, vmax, cmap, scientific=False, cbarlabel=None,
+def colorbar_hack(ax, vmin, vmax, cmap, scientific=False, cbarlabel=None, norm=None,
                   **kwargs):
     """
-    Colorbar hack to insert colorbar on ternary plot. 
-    
+    Colorbar hack to insert colorbar on ternary plot.
+
     Called by heatmap, not intended for direct usage.
-    
+
     Parameters
     ----------
     vmin: float
@@ -88,7 +88,8 @@ def colorbar_hack(ax, vmin, vmax, cmap, scientific=False, cbarlabel=None,
 
     """
     # http://stackoverflow.com/questions/8342549/matplotlib-add-colorbar-to-a-sequence-of-line-plots
-    norm = plt.Normalize(vmin=vmin, vmax=vmax)
+    if norm is None:
+        norm = plt.Normalize(vmin=vmin, vmax=vmax)
     sm = plt.cm.ScalarMappable(cmap=cmap, norm=norm)
     sm._A = []
     cb = plt.colorbar(sm, ax=ax, **kwargs)


### PR DESCRIPTION
I really like the ternary plotting library and its flexability! I have however wondered if its possible to have a logarithmic colorbar and I couldn't find a way to do it. This pull request therefore adjusts the `colorbar_hack` by extending the function arguments by `norm`.

With this small adjustment, a log colorbar can be created using:

```py 
norm = colors.LogNorm(vmin=c.min(), vmax=c.max())  # you can use any norm you prefer
cb_kwargs = {"norm":norm}  # at least the norm argument should be passed
tax.scatter(xyz, norm=norm, c=c, vmax=norm.vmax, vmin=norm.vmin, cb_kwargs=cb_kwargs, marker='s',  colorbar=True, colormap='viridis')  # norm should be passed here again
```

Here is an example:
![dreieck](https://user-images.githubusercontent.com/7556347/86749848-d6f2dd00-c03d-11ea-900a-b39f396af701.png)