### PR TITLE
`triangular` is default heatmap style, in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ will evaluate the function at the specified number of steps (determined by the
 scale, expected to be an integer in this case). The simplex can be split up into
 triangles or hexagons and colored according to one of three styles:
 
-- Triangular -- `triangular`: coloring triangles by summing the values on the
+- Triangular -- `triangular` (default): coloring triangles by summing the values on the
 vertices
 - Dual-triangular  -- `dual-triangular`: mapping (i,j,k) to the upright
 triangles &#9651; and blending the neigboring triangles for the downward


### PR DESCRIPTION
Helpful to point this out, in case there is any confusion

https://github.com/marcharper/python-ternary/blob/96decd73de2621ef4228773bdf082197f0ffe698/ternary/heatmapping.py#L189-L191