### PR TITLE
Add passing of colorbar to matplotlib scatter plot

### DIFF
--- a/ternary/plotting.py
+++ b/ternary/plotting.py
@@ -145,7 +145,7 @@ def scatter(points, ax=None, permutation=None, colorbar=False, colormap=None,
     if not ax:
         fig, ax = plt.subplots()
     xs, ys = project_sequence(points, permutation=permutation)
-    ax.scatter(xs, ys, vmin=vmin, vmax=vmax, **kwargs)
+    ax.scatter(xs, ys, vmin=vmin, vmax=vmax, cmap=colormap, **kwargs)
 
     if colorbar and (colormap != None):
         if cb_kwargs != None:


### PR DESCRIPTION
The colormap was not passed to the matplotlib object, therefore when using non-default colormaps, the color of the scatter points did not coincide with the displayed colormap. This can be reproduced with the following code
```python
import ternary
fig, tax = ternary.figure(scale=20)
tax.set_axis_limits({'b': [0, 100], 'l': [0, 100], 'r': [0, 100]})
points = tax.convert_coordinates([[50,50,50]])
tax.scatter(points, c=[10], vmin=5, vmax=10, colorbar=True, colormap="jet")
```